### PR TITLE
Changed setContentArea function for multiple editors

### DIFF
--- a/src/js/jquery.notebook.js
+++ b/src/js/jquery.notebook.js
@@ -469,7 +469,7 @@
                 }
             },
             setContentArea: function(elem) {
-                var id = $('body').find('.jquery-editor').length + 1;
+                var id = $('body').find('.jquery-notebook').length + 1;
                 elem.attr('data-jquery-notebook-id', id);
                 var body = $('body');
                 contentArea = $('<textarea></textarea>');


### PR DESCRIPTION
Changed the setContentArea function to allow for multiple editors. Currently all reference the same hidden textarea.

Changed .jquery-editor to .jquery-notebook.
